### PR TITLE
Fix <> tags that do not show up at all in a browser

### DIFF
--- a/dynamicvdb-datafederation/README.md
+++ b/dynamicvdb-datafederation/README.md
@@ -120,7 +120,7 @@ NOTE: There currently isn't a JBoss AS plugin option for undeploying the rar and
 
 ==== Using the simpleclient example ====
 
-1) Change your working directory to ${quickstart.install.dir}/simpleclient"
+1) Change your working directory to "${quickstart.install.dir}/simpleclient"
 
 2) Use the simpleclient example to run the following queries:
 


### PR DESCRIPTION
I tried to read the README.md from a browser, and the <JBOSS_HOME> references didn't show up at all, which confused me a bunch.
