### PR TITLE
updated jdg-remote-cache quickstarts

### DIFF
--- a/jdg-remote-cache-materialization/README.adoc
+++ b/jdg-remote-cache-materialization/README.adoc
@@ -22,9 +22,9 @@ This quickstart demonstrates how Teiid can connect to a remote JBoss Data Grid (
 * link:../README.adoc#_downloading_and_installing_teiid[Teiid Server]
 * link:../simpleclient/README.adoc[Simple Client]
 * link:../vdb-datafederation/README.adoc[vdb-datafederation]
-* JDG 6.5 eap modules kit (used by Teiid to access the remote cache)
-* JDG 6.5 server kit (used as the remote server)
-* JDG 6.5 quickstart kit (used to configure remote cache and initialize data)
+* JDG Hot Rod Client eap modules kit (used by Teiid to access the remote cache)
+* JDG server kit (used as the remote server)
+* JDG quickstart kit (used to configure remote cache and initialize data)
 
 NOTE: You can obtain JDG kit distributions on Red Hat's Customer Portal at https://access.redhat.com/jbossnetwork/restricted/listSoftware.html
 
@@ -34,7 +34,9 @@ NOTE: You can obtain JDG kit distributions on Red Hat's Customer Portal at https
 
 * Install the JDG server
 * Configure caches based on the link:./JDG_SERVER_README.adoc[JDG_SERVER_README.adoc]
-* It is assumed that you will be running both servers on the same box, there start the JDG server by adding the following command line argument: -Djboss.socket.binding.port-offset=100
+* It is assumed that you will be running both servers on the same box, there start the JDG server by adding the following command line argument: 
+
+        -Djboss.socket.binding.port-offset=100
 
 [source,xml]
 .*Example*
@@ -44,9 +46,9 @@ NOTE: You can obtain JDG kit distributions on Red Hat's Customer Portal at https
 
 For the purpose of this quick start, it assumes running both servers on the same machine and is expecting the JDG server to have its ports incremented. The port adjustment has been made in the setup.cli script to match the above offset.
 
-=== 2. db-datafederation quickstart
+=== 2. vdb-datafederation quickstart
 
-Refer to link:../vdb-datafederation/README.adoc[vdb-datafederation] for installing db-datafederation quickstart.
+Refer to link:../vdb-datafederation/README.adoc[vdb-datafederation] for installing vdb-datafederation quickstart.
 
 === 3. Teiid jdg-remote-cache-materialization quickstart Setup
 
@@ -64,13 +66,13 @@ After building the quickstart, the `jdg-remote-cache-materialization-pojos-jboss
 
 a. Shutdown Teiid server, if not already. 
 
-b. Take the target/jdg-remote-cache-pojos-jboss-as7-dist.zip and unzip at /modules/
+b. Take the target/jdg-remote-cache-pojos-wildfly-dist.zip and unzip at JBOSS_HOME
 
-c. Install the JBoss Data Grid version of the hot rod client modules kit for EAP into /modules/ of your Teiid/EAP instance. See Red Hat: http://access.redhat.com to obtain the kit.
+c. Install the JBoss Data Grid version of the hot rod client modules kit for EAP into /modules/ of your Teiid server instance. See Red Hat: http://access.redhat.com to obtain the kit.
 
-* Setup the infinispan resource adapter
+* Setup the infinispan hotrod resource adapter
 
-a. Configure for reading and writing to a remote cache, open the file: {jbossas.server.dir}/docs/teiid/datasources/infinispan/infinispan-remote-query-materialize-annotations-dsl-ds.xml
+a. Configure for reading and writing to a remote cache, open the file: {jbossas.server.dir}/docs/teiid/datasources/infinispan-hotrod/infinispan-hotrod-materialize-annotations-dsl-ds.xml
 
 b. Copy and paste the resource-adapter section it into the server configuration, under the section.
 
@@ -92,16 +94,16 @@ If Teiid isn't configured in the default configuration, append the following arg
 ./standalone.sh -c standalone-teiid.xml
 ----
 
-* Install the infinispan-cache-dsl translator
+* Install the infinispan-hotrod translator
 
 ----
 cd $\{JBOSS_HOME}/bin
-./jboss-cli.sh --connect --file={jbossas.server.dir}/docs/teiid/datasources/infinispan/add-infinispan-cache-dsl-translator.cli
+./jboss-cli.sh --connect --file={JBOSS_HOME}/docs/teiid/datasources/infinispan-hotrod/add-ispn-hotrod-translator.cli
 ----
 
 === 4. deploy the VDB
 
-Deploy for reading/writing to a remote cache, copy files jdg-remote-cache-mat-vdb.xml and jdg-remote-cache-mat-vdb.xml.dodeploy to {jbossas.server.dir}/standalone/deployments
+Deploy for reading/writing to a remote cache, copy files jdg-remote-cache-mat-vdb.xml and jdg-remote-cache-mat-vdb.xml.dodeploy to {JBOSS_HOME}/standalone/deployments
 
 == Query Demonstrations
 

--- a/jdg-remote-cache-materialization/kits/wildfly-dist.xml
+++ b/jdg-remote-cache-materialization/kits/wildfly-dist.xml
@@ -1,7 +1,7 @@
 <!--This script builds a zip for Teiid Server Installation -->
 <assembly>
   
- <id>jboss-as7-dist</id> 
+ <id>wildfly-dist</id> 
   
   <formats>
     <format>zip</format>
@@ -12,8 +12,8 @@
 
  <fileSets>
     <fileSet>
-        <directory>kits/jboss-as7/modules</directory>
-        <outputDirectory>.</outputDirectory>     
+        <directory>kits/wildfly/modules</directory>
+        <outputDirectory>modules</outputDirectory>     
         <filtered>true</filtered> 
         <includes>
           <include>**/*</include>
@@ -21,10 +21,10 @@
     </fileSet>     
    <fileSet>
         <directory>target</directory>
-        <outputDirectory>com/client/quickstart/addressbook/pojos/main/</outputDirectory>     
+        <outputDirectory>modules/com/client/quickstart/addressbook/pojos/main/</outputDirectory>     
         <filtered>false</filtered> 
         <includes>
-          <include>jdg-remote-cache-pojos.jar</include>
+          <include>jdg-remote-cache-materialization-pojos.jar</include>
         </includes>   
     </fileSet>        
   </fileSets>

--- a/jdg-remote-cache-materialization/kits/wildfly/modules/com/client/quickstart/addressbook/pojos/main/module.xml
+++ b/jdg-remote-cache-materialization/kits/wildfly/modules/com/client/quickstart/addressbook/pojos/main/module.xml
@@ -6,9 +6,9 @@
     </resources>
 
     <dependencies>
-        <module name="org.infinispan.client.hotrod" slot="jdg-6.6" optional="true" services="export"/>
-   	<module name="org.infinispan.protostream" slot="jdg-6.6"  optional="true" services="export"/>
+        <module name="org.infinispan.client.hotrod" slot="${jdg.slot}" optional="true" services="export"/>
+   	<module name="org.infinispan.protostream" slot="${jdg.slot}"  optional="true" services="export"/>
 
-        <module name="org.jboss.teiid.resource-adapter.infinispan.dsl" export="true" />
+        <module name="org.jboss.teiid.resource-adapter.infinispan.hotrod" export="true" />
     </dependencies>
 </module>

--- a/jdg-remote-cache-materialization/pom.xml
+++ b/jdg-remote-cache-materialization/pom.xml
@@ -117,7 +117,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
-						<descriptor>kits/jboss-as7-dist.xml</descriptor>
+						<descriptor>kits/wildfly-dist.xml</descriptor>
 					</descriptors>
 				</configuration>
 				<executions>

--- a/jdg-remote-cache-materialization/src/vdb/jdg-remote-cache-mat-vdb.xml
+++ b/jdg-remote-cache-materialization/src/vdb/jdg-remote-cache-mat-vdb.xml
@@ -56,7 +56,7 @@
 	</model>               
          
   
-    <translator name="infinispan1" type="infinispan-cache-dsl">
+    <translator name="infinispan1" type="ispn-hotrod">
 
        <property name="SupportsDirectQueryProcedure" value="true"/>
        <property name="SupportsNativeQueries" value="true"/>

--- a/jdg-remote-cache/README.adoc
+++ b/jdg-remote-cache/README.adoc
@@ -5,7 +5,7 @@
 |Level |Technologies |Target Product |Product Versions |Source
 
 |Intermediate
-|Teiid, Infinispan, Hot Rod, Remote Query
+|Teiid, Infinispan, Hot Rod, Remote Query, Protobuf Annotations
 |DV
 |DV 6.1+, JDG 6.5+
 |https://github.com/teiid/teiid-quickstarts
@@ -13,7 +13,9 @@
 
 == What is it?
 
-This quickstart demonstrates how Teiid can connect to a remote JBoss Data Grid (JDG) as a data source, to query and update data from cache using the Hot Rod protocol.
+This quickstart demonstrates how Teiid can connect to a remote JBoss Data Grid (JDG) as a data source, to query and update data in cache using the Hot Rod protocol.
+
+This example is using the protobuf annotations feature of JDG for configuring the protobuf definition file and the marshaller. 
 
 == System requirements
 
@@ -21,9 +23,9 @@ This quickstart demonstrates how Teiid can connect to a remote JBoss Data Grid (
 * link:../README.adoc#_downloading_and_installing_maven[Maven]
 * link:../README.adoc#_downloading_and_installing_teiid[Teiid Server]
 * link:../simpleclient/README.adoc[Simple Client]
-* JDG 6.5 eap modules kit (used by Teiid to access the remote cache)
-* JDG 6.5 server kit (used as the remote server)
-* JDG 6.5 quickstart kit (used to configure remote cache and initialize data)
+* JDG Hot Rod client eap modules kit (used by Teiid to access the remote cache)
+* JDG server kit (used as the remote server)
+* JDG quickstart kit (used to configure remote cache and initialize data)
 
 NOTE: You can obtain JDG kit distributions on Red Hat's Customer Portal at https://access.redhat.com/jbossnetwork/restricted/listSoftware.html
 
@@ -33,7 +35,9 @@ NOTE: You can obtain JDG kit distributions on Red Hat's Customer Portal at https
 
 * Install the JDG server
 * Configure caches based on the link:./JDG_SERVER_README.adoc[JDG_SERVER_README.adoc]
-* It is assumed that you will be running both servers on the same box, there start the JDG server by adding the following command line argument: -Djboss.socket.binding.port-offset=100
+* It is assumed that you will be running both servers on the same box, therefore, start the JDG server by adding the following command line argument: 
+
+-Djboss.socket.binding.port-offset=100
 
 [source,xml]
 .*Example*
@@ -51,7 +55,7 @@ build the jdg-remote-cache quickstart
 mvn -s ./settings.xml clean install
 ----
 
-After building the quickstart, the `jdg-remote-cache-pojos-jboss-as7-dist.zip` should be found in the target directory. This zip will be used later, where it is deployed to the Teiid server.
+After building the quickstart, the `jdg-remote-cache-pojos-wildfly-dist.zip` should be found in the target directory. This zip will be used later, where it is deployed to the Teiid server.
 
 === 3. Setup Teiid Server
 
@@ -59,13 +63,13 @@ After building the quickstart, the `jdg-remote-cache-pojos-jboss-as7-dist.zip` s
 
 a. Shutdown Teiid server, if not already. 
 
-b. Take the target/jdg-remote-cache-pojos-jboss-as7-dist.zip and unzip at /modules/
+b. Take the target/jdg-remote-cache-pojos-wildfly-dist.zip and unzip at JBOSS_HOME
 
-c. Install the JBoss Data Grid version of the hot rod client modules kit for EAP into /modules/ of your Teiid/EAP instance. See Red Hat: http://access.redhat.com to obtain the kit.
+c. Install the JBoss Data Grid version of the hot rod client eap modules kit for EAP into /modules/ of your Teiid server instance. See Red Hat: http://access.redhat.com to obtain the kit.
 
-* Setup the infinispan resource adapter
+* Setup the infinispan hotrod client resource adapter
 
-a. Configure for reading and writing to a remote cache, open the file: {jbossas.server.dir}/docs/teiid/datasources/infinispan/infinispan-remote-query-dsl-ds.xml
+a. Configure for reading and writing to a remote cache, open the file: {jbossas.server.dir}/docs/teiid/datasources/infinispan-hotrod/infinispan-hotrod-annotations-ds.xml
 
 b. Copy and paste the resource-adapter section it into the server configuration, under the section.
 
@@ -87,16 +91,16 @@ If Teiid isn't configured in the default configuration, append the following arg
 ./standalone.sh -c standalone-teiid.xml
 ----
 
-* Install the infinispan-cache-dsl translator
+* Install the infinispan-hotrod translator
 
 ----
 cd $\{JBOSS_HOME}/bin
-./jboss-cli.sh --connect --file={jbossas.server.dir}/docs/teiid/datasources/infinispan/add-infinispan-cache-dsl-translator.cli
+./jboss-cli.sh --connect --file={JBOSS_HOME}/docs/teiid/datasources/infinispan/add-ispn-hotrod-translator.cli
 ----
 
 === 4. deploy the VDB
 
-Deploy for reading/writing to a remote cache, copy files infinispan-dsl-cache-vdb.xml and infinispan-dsl-cache-vdb.xml.dodeploy to {jbossas.server.dir}/standalone/deployments
+Deploy for reading/writing to a remote cache, copy files infinispan-dsl-cache-vdb.xml and infinispan-dsl-cache-vdb.xml.dodeploy to {JBOSS_HOME}/standalone/deployments
 
 === 5. JDG Remote Cache initialization
 
@@ -104,7 +108,7 @@ NOTE: The following build command assumes you have configured your Maven user se
 
 a. Make sure you have started the JDG as described above.
 
-b. Open a command line and navigate to the root directory of this teiid jdg-remote quickstart.
+b. Open a command line and navigate to the root directory of this teiid jdg-remote-cache quickstart.
 
 c. If you need to, rebuild the quick start
 

--- a/jdg-remote-cache/kits/wildfly-dist.xml
+++ b/jdg-remote-cache/kits/wildfly-dist.xml
@@ -1,7 +1,7 @@
 <!--This script builds a zip for Teiid Server Installation -->
 <assembly>
   
- <id>jboss-as7-dist</id> 
+ <id>wildfly-dist</id> 
   
   <formats>
     <format>zip</format>
@@ -12,8 +12,8 @@
 
  <fileSets>
     <fileSet>
-        <directory>kits/jboss-as7/modules</directory>
-        <outputDirectory>.</outputDirectory>     
+        <directory>kits/wildfly/modules</directory>
+        <outputDirectory>modules</outputDirectory>     
         <filtered>true</filtered> 
         <includes>
           <include>**/*</include>
@@ -21,10 +21,10 @@
     </fileSet>     
    <fileSet>
         <directory>target</directory>
-        <outputDirectory>com/client/quickstart/addressbook/pojos/main/</outputDirectory>     
+        <outputDirectory>modules/com/client/quickstart/addressbook/pojos/main/</outputDirectory>     
         <filtered>false</filtered> 
         <includes>
-          <include>jdg-remote-cache-materialization-pojos.jar</include>
+          <include>jdg-remote-cache-pojos.jar</include>
         </includes>   
     </fileSet>        
   </fileSets>

--- a/jdg-remote-cache/kits/wildfly/modules/com/client/quickstart/addressbook/pojos/main/module.xml
+++ b/jdg-remote-cache/kits/wildfly/modules/com/client/quickstart/addressbook/pojos/main/module.xml
@@ -9,6 +9,6 @@
         <module name="org.infinispan.client.hotrod" slot="${jdg.slot}" optional="true" services="export"/>
    	<module name="org.infinispan.protostream" slot="${jdg.slot}"  optional="true" services="export"/>
 
-        <module name="org.jboss.teiid.resource-adapter.infinispan.dsl" export="true" />
+        <module name="org.jboss.teiid.resource-adapter.infinispan.hotrod" export="true" />
     </dependencies>
 </module>

--- a/jdg-remote-cache/pom.xml
+++ b/jdg-remote-cache/pom.xml
@@ -117,7 +117,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
-						<descriptor>kits/jboss-as7-dist.xml</descriptor>
+						<descriptor>kits/wildfly-dist.xml</descriptor>
 					</descriptors>
 				</configuration>
 				<executions>

--- a/jdg-remote-cache/src/vdb/infinispan-dsl-cache-vdb.xml
+++ b/jdg-remote-cache/src/vdb/infinispan-dsl-cache-vdb.xml
@@ -9,7 +9,7 @@
     <model name="People" type="Physical">
         <property name="importer.useFullSchemaName" value="false"/>
            
-        <source name="infinispan-cache-dsl-connector" translator-name="infinispan-cache-dsl" connection-jndi-name="java:/infinispanRemoteDSL" />
+        <source name="infinispan-cache-dsl-connector" translator-name="ispn-hotrod" connection-jndi-name="java:/infinispanRemoteDSL" />
     </model>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!--version.org.hibernate.search>4.5.0.Final</version.org.hibernate.search-->
                 <version.org.infinispan.6>7.2.3.Final</version.org.infinispan.6>  
         <!-- JDG module slot to use  -->
-                <jdg.slot>jdg-7.2</jdg.slot>  
+                <jdg.slot>jdg-7.0</jdg.slot>  
   		<version.net.jcip>1.0</version.net.jcip>
                 <version.resteasy.client>3.0.16.Final</version.resteasy.client>
         


### PR DESCRIPTION
updated jdg-remote-cache quickstarts to use  wildfly and reference the reorganized hotrod resource-adapter and translator