### PR TITLE
Reformated asciidoc syntax to markdown in quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The following is a list of the currently available quick starts. The table lists
 
 Some quick starts are designed to enhance or extend other quick starts. These are noted in the **Prerequisites** column. If a quick start lists prerequisites, those must be installed or deployed before working with the quick start.
 
-|===
+
 | **Quick start Name** | **Features Demonstrated** | **Description** | **Prerequisites** |
-|:-----------|:-----------|:-----------|:-----------|:-----------|
+|:-----------|:-----------|:-----------|:-----------|
 | [datafederation](dynamicvdb-datafederation/README.md "data-federation") | Data Federation, TEXTTABLE, Native Query, VDB Reuse, External Materialization, Excel File | Shows how to expose multiple data sources for data federation and externally materialize a view to improve performance | None |
 | [dataroles](dynamicvdb-dataroles/README.md "data-roles") | Data roles | Shows how to control Read/Write data access using data roles and masking | datafederation |
 | [materialization](dynamicvdb-materialization/README.md "materialization") | Materialization | Demonstrates how to configure external materialization to so that caching can be used to improve query performance. | datafederation |
@@ -47,7 +47,7 @@ Some quick starts are designed to enhance or extend other quick starts. These ar
 | [hbase-as-a-datasource](hbase-as-a-datasource/README.md) | 'hbase' Translator, FOREIGN TABLE DDL | Demonstrates using the Hbase Translator via the Pheonix driver | Hbase be installed |
 | [drools-integration](drools-integration/README.md) | Drools integration, UDF, FOREIGN Function DDL | Demonstrates using a simple rules invocation via a Function | |
 | [socialMedia-as-a-datasource](socialMedia-as-a-datasource/README.md) | 'ws' Translator, accessing security rest service | Demonstrates using the WS Translator to call secured rest services, including Social Media(Twitter, Facebook, Weibo, etc), and transform the web service results into relational results | |
-|===
+
 
 -------------------
 <a id="systemrequirements"></a>


### PR DESCRIPTION
There was invalid markdown content in README.md due to copying from master branch which uses asciidoc.